### PR TITLE
docs: publish current GRAND operating guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,128 +1,94 @@
-## [Unreleased]
+# Changelog
 
+Material GRAND changes are recorded here. The repository's Git history remains the detailed source of truth.
+
+## Unreleased
+
+### Documentation
+
+- Replaced the stale project overview with current setup, architecture, feature, verification, and operations guidance.
+- Added a documentation map and expanded reporting onboarding, scheduling, permissions, and existing-template guidance.
+
+## 2026-08-14
+
+### Configurable reporting automation
+
+- Added a reusable, department-bounded reporting platform piloted with MSWD.
+- Added allowlisted dataset adapters, configurable fields and filters, grouping, totals, sorting, and period selection without arbitrary SQL or executable template content.
+- Added versioned official layouts and safe reference uploads for familiar PDF, spreadsheet, Word, and image forms.
+- Added PDF, XLSX, and CSV generation with exact configuration snapshots, checksums, immutable audit events, and archived outputs.
+- Added manual and daily, weekly, monthly, quarterly, and annual scheduled runs backed by an idempotent ledger and safe retries.
+- Added generated, reviewed, approved, failed, and superseded states with explicit permissions and department boundaries.
+- Added five MSWD presets: Assistance volume and status, program accomplishments, aggregate reach, activity schedules, and workload.
+- Added reporting indicators to department dashboards and synthetic portfolio screenshots for the reporting workspace and approval flow.
+
+### Citizen profiles and service history
+
+- Added a permission-restricted citizen review queue with search, sorting, pagination, assignment, notes, review states, and audit history.
+- Added neutral Assistance usage summaries and duplicate-candidate indicators without treating frequency as fraud, risk, or eligibility evidence.
+- Kept `CitizenProfile` as the canonical citizen identity and established an adapter path for future approved government services.
+
+### Professional configurable interface
+
+- Added configurable institutional labels, colors, logos, hero imagery, footer content, service-card labels, links, icons, and ordering.
+- Improved public and employee navigation for plain-language, keyboard-accessible, responsive use.
+- Updated synthetic showcase data, screenshots, captions, and the portfolio manifest.
+
+### MSWD programs and dashboards
+
+- Reworked the MSWD login landing page as a department workspace with Assistance as a linked processing module.
+- Added internal social-welfare programs and activities with ownership, schedules, venues, operational status, aggregate attendance, outcomes, permissions, and audit timestamps.
+- Preserved reusable department-dashboard contracts for future offices and modules.
+
+### Maintenance
+
+- Updated and audited Python dependencies, security workflows, Dependabot configuration, and the minimal browser asset bundle.
+- Expanded leave-credit policy and adjustment controls while preserving predictable accrual and half-day request increments.
 
 ## 2025-08-11
-## [Unreleased]
-### 🔧 Changed
-- Removed Telegram bot integration from assistance request workflow.
-- Updated `views.py` and `cron.py` to route status and file-related updates to email instead of Telegram.
 
-### 🧹 Housekeeping
-- Cleaned up unused Telegram bot code to reduce background processes on deployment.
-- Prepared migration path for exclusive email-based notifications.
+### Changed
 
+- Removed Telegram delivery from the Assistance request workflow and routed status and document updates through email.
+- Removed unused bot behavior from the active deployment path while retaining the historical app for compatibility checks.
 
 ## 2025-06-27
-### ✨ Added
-- Two-step flow for submitting assistance requests:
-  - **Step 1**: Personal and request info
-  - **Step 2**: Upload supporting documents via edit link
-- AJAX-based document upload with:
-  - Document type selection
-  - Real-time feedback and previews
-  - Status-based restrictions (cannot replace approved files)
-- File preview thumbnails for images on the edit page
-- UI indicators (dot progress) to guide users through multi-step process
 
-### 🔧 Changed
-- Separated document upload form from the initial submission form
-- Improved status display and remark visibility for uploaded files
-- Updated submission confirmation email with clearer instructions
+### Assistance submission workflow
 
-### 🐛 Fixed
-- URL reverse errors for `upload_document_ajax`
-- Custom `basename` template filter not loading due to missing templatetag config
-- Session corruption warnings on improper form structure
-- JS logic now prevents uploads of already approved files
+- Added a two-step request flow: personal/request information followed by supporting-document upload through the secure edit link.
+- Added asynchronous upload feedback, previews, document-type selection, and approved-file replacement restrictions.
+- Added progress indicators and clearer confirmation-email instructions.
+- Fixed upload route reversal, template-filter loading, malformed form behavior, and approved-file client-side safeguards.
 
+## 2025-06-26
 
-## [2025-06-26] Assistance App
-### ✨ Added
-- Telegram bot handler (`telegram_bot/bot_handler.py`) with `/start`, `/unlink`, and secure request linking
-- Telegram notifications for document updates (in `mswd_update_document_ajax`) if user is linked
-- Environment variable support via `.env` for `TELEGRAM_BOT_TOKEN`
+### Historical Telegram integration
 
-### 🔒 Security
-- Only requests with `claimed_at=None` can be linked or receive messages
-- Reference + Edit code required to link; prevents unauthorized access
-- Telegram messages gracefully fail if request no longer exists
+- Added request linking and notifications through a Telegram bot, protected by reference and edit codes.
+- Restricted linking to unclaimed requests and added environment-based token configuration.
+- This integration was removed from active Assistance delivery on 2025-08-11.
 
-### 🧹 Housekeeping
-- Telegram bot logs to `telegram_bot.log`
-- Inline bot logic included in AJAX view instead of helper for now
-- Test data cleanup to be done manually before live deployment
+## 2025-06-25
 
+### Profiles and edit history
 
-## [2025-06-25] Profiles App – Edit Logs and HR Metadata Expansion
+- Added `ProfileEditLog` with editor, section, note, and timestamp metadata.
+- Added role-aware profile editing and restricted HR employment metadata.
+- Added government identifiers, hiring dates, department memo uploads, and profile edit-history presentation.
+- Fixed missing-slug redirects and log rendering when the editor is unavailable.
 
-### Added
-- `ProfileEditLog` model to track profile edits with section, note, timestamp, and editor metadata.
-- HR/admin edit log display in `profile.html` (visible to profile owner or admins only).
-- Colored highlight (`bg-light border-left-info`) for HR/admin-initiated changes in logs.
-- Full field support in `EmploymentProfileUpdateForm`, including:
-  - Government IDs: TIN, GSIS ID, PAG-IBIG ID, PhilHealth ID, SSS ID
-  - Dates: `jo_date_hired`, `reg_date_hired`
-  - File: `assigned_department_memo` (with preview and file path)
+## 2025-06-23
 
-### Changed
-- Refactored `profileEditView` to:
-  - Detect employee vs. citizen profiles and handle forms accordingly
-  - Log edits to `ProfileEditLog` with section labeling (`Basic Info`, `HR Metadata`, etc.)
-  - Support admin-only HR metadata updates conditionally
-- `profile.html` now uses partials and includes an expandable audit log section
-- Edit forms grouped visually with Bootstrap cards and consistent form controls
+### Assistance operations
 
-### Fixed
-- Catch-block for missing slug in `get_absolute_url`, resolving `NoReverseMatch` on profile save
-- Template fallback for missing logs or null `edited_by` (displayed as “System”)
-- Fixed memo preview display when no file is uploaded (file path and click logic included)
+- Added the original MSWD request dashboard, request status history, staff-facing transparency logs, citizen email notifications, and printable request summaries.
+- Added department-aware dashboard selection and corrected template rendering for log entries.
 
-### Notes
-- Logs currently stored indefinitely; may paginate or archive in future
-- Profile page URLs still based on username (internal use); slug fallback maintained
-- Minimal performance impact expected due to low log volume
+## 2025-06-15
 
+### Assistance foundation
 
-## [2025-06-23] Assistance Dashboard and Transparency Logs
-
-### Added
-- MSWD dynamic dashboard with recent assistance request summary and quick access to request details.
-- Per-request status change logging via `RequestLog` model (action type, who updated, timestamps).
-- Transparency log display for MSWD: “who updated what and when”.
-- Email notifications sent to citizens upon status or remarks changes.
-- Printable and downloadable request summary for MSWD using `html2pdf.js`.
-
-### Changed
-- `mswd_request_detail_view`: now logs updates, sends email, and supports printable view UI.
-- Department dashboard routing now smartly loads MSWD dashboard using the `dashboard_template` field.
-
-### Fixed
-- Resolved Django template error: inline `if...else` in logs display now uses proper `{% if %}` blocks.
-
-
-## [2025-06-15] Assistance App
-### Added
-- New `assistance` app with full request lifecycle
-- Per-file review system (remarks + status flags)
-- Duplicate prevention for educational assistance
-- Reference/edit code access via landing form
-- `/assistance` all-in-one submission/tracking/edit page
-- Email resend route (`resend_codes`) – disabled in dev
-- Global alert system with link-rich contextual messages
-- Helper message block on landing page for returning users
-
-### Changed
-- Refactored user-related logic into:
-  • `profiles` app (employee data)
-  • `departments` app (head access + contacts)
-  • `salaries` app (pay computation logic)
-  • `home` app (public content)
-- Switched to AdminLTE4 + Bootstrap 5 UI consistently
-- Improved message display and error alert readability
-
-### Fixed
-- Message visibility issues on colored backgrounds
-
-### Notes
-- Email backend set to development mode (`console` or `mailtrap`)
-- Future steps: enable resend_codes mailer and activate cron jobs for status checks
+- Added the Assistance request lifecycle, supporting-document review, duplicate-period prevention, secure tracking/edit access, and contextual messages.
+- Split people, department, salary, and public-home responsibilities into their own Django apps.
+- Standardized the interface on AdminLTE and Bootstrap styling and improved alert readability.

--- a/README.md
+++ b/README.md
@@ -1,83 +1,84 @@
-## 🧩 Apps & Progress Overview
+# GRAND
 
-### `users` app
-- [x] Automatic profile creation upon user registration (with default values)
-- [x] Password reset and change workflows working in both dev and production
-  ↪ Uses [Mailtrap](https://mailtrap.io) for dev; live SMTP in production
-- [x] Secure registration/login for internal users (admin/employee)
-- [x] Integrated `django-allauth` for future external signups (already-running in prod, as well)
+GRAND is a department-aware local-government service platform built with Django. It gives citizens clear public service flows and gives employees workspaces that reflect their assigned department, role, and permissions.
 
-**Next steps:**  
-- [ ] Finalize role assignment logic for external users upon registration
+The current MSWD pilot combines Assistance request processing, social-welfare program operations, citizen review, and governed report generation. The same department and permission contracts are intended to support additional municipal offices without duplicating the platform.
 
----
+## Current capabilities
 
-### `profiles` app
+- Configurable public identity, service cards, icons, media, colors, and plain-language navigation.
+- Dynamic employee dashboards with department-specific modules, leadership, team, plantilla, leave, contacts, and announcements.
+- Assistance submission, secure editing and tracking, document review, status history, notifications, and separate MSWD processing views.
+- Internal social-welfare programs and activities for seminars, feeding programs, outreach, distributions, schedules, venues, attendance totals, and outcomes.
+- Permission-restricted citizen review with assistance usage history, duplicate-candidate indicators, review ownership, notes, and audit events.
+- Leave requests and predictable credit accrual with approval deductions.
+- Cross-department reporting definitions, versioned layouts, PDF/XLSX/CSV output, recurring schedules, checksums, review, approval, and supersession.
+- Public and internal announcements, employee/citizen profiles, department records, and organization views.
 
-- [x] Split from `users` for handling both `EmployeeProfile` and `CitizenProfile` data  
-- [x] Auto-generated slug URLs with fallback to username  
-- [x] Role-aware profile editing view (separate HR-only and owner-only sections)  
-- [x] HR metadata form with support for government IDs, position info, and department memo uploads  
-- [x] Editable memo image field with preview and re-saving support  
-- [x] Profile edit logging via `ProfileEditLog` model  
-  ↪ Tracks editor, section changed, notes, and timestamp  
-  ↪ Separate styling for HR/admin edits in view-only logs  
-- [x] Inline profile edit history displayed conditionally on `profile.html`
+GRAND keeps operational modules separate: an employee's dashboard summarizes work and links to specialized workspaces instead of embedding full processing screens in the landing page.
 
-**Next steps:**  
-- [ ] Add pagination or load-more for logs  
-- [ ] Optionally add reason-for-edit dropdown or tag system
+## Application map
 
----
+| Area | Django app | Primary responsibility |
+| --- | --- | --- |
+| Public portal and dashboards | `home` | Site identity, navigation, announcements, and login landing context |
+| People and identity | `users`, `profiles` | Authentication, employee profiles, citizen profiles, and review history |
+| Organization | `departments` | Department identity, leadership, membership, and department boundaries |
+| Assistance | `assistance` | Citizen requests, supporting documents, staff processing, and request audit trail |
+| Programs and activities | `social_welfare` | Internal MSWD program and activity operations |
+| Reports | `reporting` | Controlled datasets, layouts, generation, schedules, approvals, and archives |
+| Workforce | `leave_mgt`, `salaries` | Leave workflows and salary-related records |
 
-### `leave` app
-- [x] Permissions handled via template logic  
-- [x] Leave request auto-deductions for SL/VL on approval  
-- [x] Automatic exclusion of weekends in date range  
-- [x] Basic validation (`start_date < end_date`)  
-- [x] Global context processor for consistent template variables  
-- [x] Cron jobs for monthly leave accrual running as expected
+## Local development
 
-**In progress / Notes:**  
-- [ ] Manual holiday configuration (branch: `working-days`)  
-- [ ] Consider converting leave credits to 15-minute increments  
-- [ ] Policy improvements for leave accumulation
+Python 3.11 is the currently verified runtime. From PowerShell in the repository root:
 
----
+```powershell
+py -3.11 -m venv env
+.\env\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+python manage.py migrate
+python manage.py seed_reporting_presets
+python manage.py runserver
+```
 
-### `announcements` app
-- [x] Basic structure: public/internal, pinned, draft vs posted  
-- [ ] Redesign user-facing views
+Local development uses SQLite, the console email backend, and `src.settings.dev` by default. Do not commit local database or uploaded-media changes. Production uses `src.settings.prod`, MySQL, HTTPS security settings, SMTP, and environment-provided secrets.
 
----
+The reporting seed command is idempotent: it creates or preserves the five MSWD pilot definitions without duplicating them. See [Reporting operations](docs/REPORTING.md) before configuring templates or scheduled runs.
 
-### `salary` app *(remodel pending)*
-- [ ] Logic planning stage — will affect multiple modules  
-- [ ] Will consolidate all pay-related computations into `EmployeeSalaryDetails`
+## Verification
 
----
+Install the development-only audit tool when performing security maintenance:
 
-### `working_days` app *(not started)*
-- [ ] Needed for holiday detection, leave and salary integration, and calendar generation
+```powershell
+python -m pip install -r requirements-dev.txt
+python -m pip check
+python -m pip_audit -r requirements.txt
+python manage.py check
+python manage.py makemigrations --check --dry-run
+python manage.py test
+```
 
----
+Run due report schedules safely with:
 
-### `assistance` app *(updated)*
-- [x] User-facing financial assistance request submission with multi-file upload  
-- [x] Anonymous request editing and status tracking via secure reference and edit codes  
-- [x] Responsive AdminLTE4 + Bootstrap 5 templates for submit, edit, track, and confirmation pages  
-- [x] Per-file remarks and status flags for MSWD review  
-- [x] Reference code + edit code authentication for request access  
-- [x] Duplicate submission prevention based on period, semester, and email  
-- [x] Locked editing for approved/claimed requests  
-- [x] Message enhancements with contextual helper links  
-- [x] Landing page helper for retrieving lost access links  
-- [x] MSWD dashboard with recent request summary and quick access tools  
-- [x] Printable and downloadable request views (citizen + MSWD versions)  
-- [x] Transparent per-update logs with timestamp and responsible user  
-- [x] Automatic email alerts on status/remarks change (opt-out ready)  
-- [x] Email confirmation and notifications active in production
-  ↪ Status updates, file remarks, and submission confirmations all trigger alerts
-- [x] Removed Telegram bot dependency — all updates now delivered via email for broader accessibility
+```powershell
+python manage.py run_scheduled_reports
+```
 
+Repeated invocations for the same scheduled period do not create duplicate outputs.
 
+## Documentation
+
+- [Documentation map](docs/README.md)
+- [Reporting operations and governance](docs/REPORTING.md)
+- [Product roadmap](docs/ROADMAP.md)
+- [Security maintenance](SECURITY.md)
+- [Synthetic portfolio screenshots](output/playwright/grand-portfolio/README.md)
+- [Change history](CHANGELOG.md)
+
+## Product direction
+
+GRAND remains the platform identity. TracePoint is reserved for the later records and physical-document custody layer: document identities, QR labels, transfers, receiving, and acknowledgements. It will remain distinct from the secure links and QR codes used by Assistance.
+
+All showcase records and screenshots are synthetic. Production citizen data, credentials, uploaded records, and generated official reports must never be added to the repository.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,6 +2,8 @@
 
 Grand treats `requirements.txt` as its deployable Python lock set. Development-only security tooling belongs in `requirements-dev.txt` so scanners do not become production dependencies.
 
+For project setup and feature documentation, start with the [GRAND README](README.md) and [documentation map](docs/README.md).
+
 ## Local verification
 
 From the repository root, install both requirement sets and run:
@@ -14,6 +16,8 @@ From the repository root, install both requirement sets and run:
 .\env\Scripts\python.exe manage.py test
 .\env\Scripts\python.exe manage.py test telegram_bot
 ```
+
+Run reporting-specific tests with `manage.py test reporting`. Generated report files and uploaded reference templates are media, not source assets; production storage must be access-controlled and backed up with its database metadata.
 
 The security workflow repeats these checks for pull requests, pushes to `master`, a weekly schedule, and manual dispatches. Dependabot checks Python dependencies weekly and GitHub Actions monthly.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# GRAND documentation
+
+Use this page as the entry point for project and operator documentation.
+
+## Start here
+
+- [Project overview and local setup](../README.md) describes the product, application boundaries, development commands, and verification gates.
+- [Reporting operations](REPORTING.md) explains approved datasets, familiar-template onboarding, generation, scheduling, permissions, and audit behavior.
+- [Product roadmap](ROADMAP.md) records completed phases and the planned records and TracePoint custody layers.
+- [Security maintenance](../SECURITY.md) covers dependency auditing, CI checks, Dependabot, and bundled browser assets.
+- [Change history](../CHANGELOG.md) summarizes material delivered work.
+
+## Showcase assets
+
+The [portfolio screenshot guide](../output/playwright/grand-portfolio/README.md) and its `manifest.json` describe the reproducible synthetic UI captures. These assets contain no production citizens or official records.
+
+## Operating principles
+
+- Department membership is a boundary, not merely a filter. Explicit permissions do not grant access to another department's records.
+- Public service flows and employee processing workspaces remain separate.
+- Planned modules do not display fabricated links, records, or statistics.
+- Citizen-service frequency is operational history, not a fraud score or eligibility decision.
+- Uploaded report examples are non-executable references. Approved native layouts generate official outputs.
+- Generated reports are not official until the required review and approval steps are complete.
+- Local databases, uploaded citizen files, secrets, and generated official reports do not belong in source control.

--- a/docs/REPORTING.md
+++ b/docs/REPORTING.md
@@ -2,6 +2,8 @@
 
 GRAND's reporting platform turns approved application data into controlled departmental outputs. It is cross-department infrastructure piloted with MSWD; new departments add dataset adapters and presets without rebuilding the generation, scheduling, or approval engine.
 
+The employee workspace is available at `/reports/`. Access is department-bounded and requires the reporting workspace permission, department-head/OIC authority, or superuser status.
+
 ## Existing government templates
 
 Authorized template managers may attach PDF, XLSX, XLS, DOCX, PNG, or JPEG reference files. GRAND stores these as non-executable references only. An uploaded file does not become an official generator and GRAND never runs embedded queries, scripts, macros, or template code.
@@ -9,6 +11,17 @@ Authorized template managers may attach PDF, XLSX, XLS, DOCX, PNG, or JPEG refer
 Each usable layout is represented by a versioned `ReportTemplateVersion` containing its title, institutional header, certification text, signatory lines, footer, document-control prefix, and controlled layout settings. The version must be approved before manual or scheduled generation. This lets an office retain a familiar form while its approved fields are mapped safely.
 
 PDF is best treated as a visual or fixed-form reference. Spreadsheet and Word references are usually easier to map when tables expand. A scanned form can also be retained as a reference, but it needs a reviewed overlay or native layout before use.
+
+### Onboarding a familiar office form
+
+1. Create or clone a report definition using an approved dataset.
+2. Select only the fields, filters, period behavior, grouping, totals, and ordering that the office needs.
+3. Upload the existing form as a reference when it helps reviewers compare the result.
+4. Create a native layout version with the institutional header, certification text, signatories, footer, document-control prefix, and controlled layout settings.
+5. Have an authorized template manager approve that version.
+6. Generate a draft output, verify it against the familiar form, and complete review and approval before distribution.
+
+Uploading a PDF is therefore optional. It preserves visual intent but does not convert the PDF into an executable template or automatically place data into it.
 
 ## Approved datasets
 
@@ -24,9 +37,30 @@ Every archived run records its department, report definition, template version, 
 
 Permissions are independently assignable for workspace access, definition management, template management, scheduling, generation, review, approval, download, and department-wide visibility. A permission never bypasses the employee's assigned department boundary. Department heads/OICs receive equivalent authority for their own department by role.
 
+| Permission | Purpose |
+| --- | --- |
+| `view_reporting_workspace` | Open the reporting workspace |
+| `manage_report_definitions` | Create and change controlled report queries |
+| `manage_report_templates` | Create and approve layout versions |
+| `schedule_reports` | Configure recurring runs |
+| `generate_reports` | Generate manual outputs |
+| `review_reports` | Mark generated outputs reviewed |
+| `approve_reports` | Approve official outputs or superseding versions |
+| `download_reports` | Download archived output files |
+| `view_department_reports` | View report records across the assigned department |
+
+Assign permissions through Django groups or individual user permissions. Prefer role-based groups in production so access reviews remain understandable.
+
 ## Operator commands
 
-After migrations, configure the MSWD pilots without duplicating existing definitions:
+Install dependencies and apply migrations before using the workspace:
+
+```powershell
+python -m pip install -r requirements.txt
+python manage.py migrate
+```
+
+Configure the MSWD pilots without duplicating existing definitions:
 
 ```powershell
 python manage.py seed_reporting_presets
@@ -39,6 +73,21 @@ python manage.py run_scheduled_reports
 ```
 
 Production checks for due schedules every ten minutes. The unique idempotency key prevents a repeated invocation from creating a duplicate output for the same scheduled period. Failed runs retain the same ledger identity and may be retried safely.
+
+For production, invoke `run_scheduled_reports` from one scheduler on a frequent interval. The repository's Django cron configuration uses ten minutes. The command determines which schedules are actually due; do not create a separate operating-system job for every report definition.
+
+Generated files live under Django's configured media storage. Back up that storage together with the database: the database preserves parameters, checksums, states, and audit events, while media storage preserves the corresponding output and reference files.
+
+## Release verification
+
+```powershell
+python manage.py check
+python manage.py makemigrations --check --dry-run
+python manage.py test reporting
+python manage.py test
+```
+
+Before deployment, also verify that the media location is writable, only intended groups hold reporting permissions, the scheduler uses the production settings module, and a synthetic scheduled run can be generated, reviewed, approved, and downloaded within its department boundary.
 
 ## TracePoint direction
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,8 @@
 # GRAND product roadmap
 
-This file records agreed future work after the MSWD Programs and Activities phase. Each implementation phase uses a dedicated `codex/` branch, tests, synthetic showcase data, portfolio screenshots, review, CI, and merge into `master`.
+This file records agreed future work after the MSWD Programs and Activities phase. Each implementation phase uses a dedicated `codex/` branch, tests, synthetic showcase data, portfolio screenshots, review, CI, and merge into `master`. See the [documentation map](README.md) for operator and project guides.
 
-## Completed — Professional, configurable civic UI
+## Completed - Professional, configurable civic UI
 
 - Use plain-language, task-oriented public and employee navigation.
 - Preserve GRAND's institutional identity while keeping branding neutral across changes in administration.
@@ -10,7 +10,7 @@ This file records agreed future work after the MSWD Programs and Activities phas
 - Remove fabricated links, campaign-specific content, and shared-template assumptions that every authenticated user is an employee.
 - Verify responsive layouts, keyboard navigation, readable contrast, real workflows, and portfolio screenshots.
 
-## Completed — Citizen profiles, review, and service history
+## Completed - Citizen profiles, review, and service history
 
 - Continue using the existing `CitizenProfile` as the canonical citizen identity; do not create a parallel identity table.
 - Provide a permission-restricted review queue/table with search, sorting, pagination, review state, assigned reviewer, review notes, review timestamps, and audit history.
@@ -33,5 +33,14 @@ The first delivery uses Assistance as the only service-history provider. The rev
 
 ## Later platform phases
 
-- Records, attachments, retention, review, approval, supersession, and controlled exports.
-- Physical-document QR identity, custody, transfer, receiving, and acknowledgement, kept separate from Assistance secure-link QR codes.
+### Records and document workflows
+
+- Attach supporting records to programs, activities, citizen service history, and generated reports.
+- Add retention, review, approval, supersession, controlled exports, and department-bounded access.
+- Allow approved report runs to become official departmental records without losing their report configuration, checksum, or audit history.
+
+### TracePoint physical-document custody
+
+- Introduce document identities, QR labels, custody, transfer, receiving, and acknowledgement after the records foundation is stable.
+- Keep TracePoint custody codes separate from Assistance secure-link QR codes.
+- Preserve GRAND as the platform identity while TracePoint names the records and physical-custody capability.


### PR DESCRIPTION
## Summary
- replace the stale, encoding-damaged README with GRAND's current architecture, capabilities, setup, and verification guidance
- add a documentation index and consolidate the 2026 feature history
- document familiar-report-template onboarding, exact reporting permissions, scheduling, backup, and release operations
- clarify the records phase and the later TracePoint physical-custody direction

## Verification
- Django system check
- migration drift check
- reporting test suite: 18 passed
- complete Django suite: 102 passed
- local Markdown link validation
- encoding-artifact scan
- git diff check

The pre-existing local db.sqlite3 modification is not included.