### PR TITLE
Release GRAND 0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Material GRAND changes are recorded here. The repository's Git history remains t
 
 ## Unreleased
 
+No material changes are pending release.
+
+## 0.6.5 - 2026-08-16
+
 ### TracePoint operations workspace (0.6.5)
 
 - Added a plain-language, department-bounded TracePoint workspace with live draft, in-transit, delivered, and discrepancy indicators.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,6 @@ Repeated invocations for the same scheduled period do not create duplicate outpu
 
 ## Product direction
 
-GRAND remains the platform identity. TracePoint is its physical-document custody capability: stable packet labels, daily employee QR credentials, confirmed transfers, delivery, and completion. It builds on the governed Records registry while remaining distinct from the secure links and QR codes used by Assistance. Delivery follows the reviewed `0.6.x` patch train in the [TracePoint contract](docs/TRACEPOINT.md).
+GRAND remains the platform identity. TracePoint is its physical-document custody capability: stable packet labels, daily employee QR credentials, confirmed transfers, delivery, and completion. It builds on the governed Records registry while remaining distinct from the secure links and QR codes used by Assistance. The completed `0.6.x` delivery train and rollout guidance are recorded in the [TracePoint contract](docs/TRACEPOINT.md).
 
 All showcase records and screenshots are synthetic. Production citizen data, credentials, uploaded records, and generated official reports must never be added to the repository.

--- a/docs/TRACEPOINT.md
+++ b/docs/TRACEPOINT.md
@@ -1,5 +1,7 @@
 # TracePoint physical custody
 
+Release status: delivered in GRAND `0.6.5` through the reviewed `0.6.0`–`0.6.5` patch train.
+
 TracePoint is GRAND's physical-document custody capability. It records who is responsible for a tagged paper packet, when responsibility changed, and whether the packet merely reached its destination or the underlying work was completed.
 
 TracePoint does not replace the Records registry, Reporting, or Assistance. Those modules remain authoritative for their digital files and business workflows. TracePoint links to them when useful and adds an auditable trail for the physical bundle.


### PR DESCRIPTION
## Release gate
- publish the dated GRAND 0.6.5 changelog
- mark the TracePoint 0.6.0–0.6.5 patch train as delivered
- preserve the operator, security, and pilot-rollout contract

## Verification
- Django system check: clean
- migration drift: none
- TracePoint suite: 38 tests passed
- complete repository suite on phase merge: 164 tests passed
- portfolio manifest: valid JSON

After CI passes and this merges, master will receive the annotated 0.6.5 tag.